### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/dummy_app/static/assets/js/feed.js
+++ b/dummy_app/static/assets/js/feed.js
@@ -3,6 +3,6 @@ document.getElementById("footer_info").innerHTML = "&copy LitReview 2022-" + new
 
 
 function update_chosen_file() {
-  document.getElementById("chosen_file").innerHTML = "Image selected: " + document.getElementById("btn_img").value.replace("C:\\fakepath\\", "");
+  document.getElementById("chosen_file").textContent = "Image selected: " + document.getElementById("btn_img").value.replace("C:\\fakepath\\", "");
   document.getElementById("remove_image").removeAttribute("hidden")
 }


### PR DESCRIPTION
Potential fix for [https://github.com/memphis-tools/dockerize_django_app_on_digitalocean/security/code-scanning/2](https://github.com/memphis-tools/dockerize_django_app_on_digitalocean/security/code-scanning/2)

To fix the problem, we need to ensure that any user-controlled input is properly escaped before being inserted into the DOM. Instead of using `innerHTML`, which can interpret the input as HTML, we should use `textContent`, which treats the input as plain text and does not execute any embedded HTML or scripts.

- Replace the use of `innerHTML` with `textContent` to prevent the input from being interpreted as HTML.
- Specifically, change line 6 in the file `dummy_app/static/assets/js/feed.js` to use `textContent` instead of `innerHTML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
