### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ jobs:
   scanning:
     name: GitGuardian scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/memphis-tools/dockerize_django_app_on_digitalocean/security/code-scanning/3](https://github.com/memphis-tools/dockerize_django_app_on_digitalocean/security/code-scanning/3)

In general, this issue is fixed by explicitly defining a `permissions` block at the workflow or job level so the `GITHUB_TOKEN` has only the scopes needed. For a scanning workflow that only needs to read repository contents, `contents: read` is usually sufficient and aligns with the CodeQL recommendation.

For this workflow, the safest change without altering functionality is to add a `permissions` block under the `scanning` job (the one CodeQL flags), specifying `contents: read`. The job uses `actions/checkout` and a scanning action but does not appear to need any write capabilities (no pushes, releases, or PR/issue modifications). We therefore add:

```yaml
    permissions:
      contents: read
```

directly under `runs-on: ubuntu-latest` for the `scanning` job. No imports or additional methods are needed; this is purely a YAML configuration change within `.github/workflows/main.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
